### PR TITLE
support mvn commands from command line instead of ide

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,4 +115,14 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
Support maven commands, e.g. `mvn packge`, when building from command line.